### PR TITLE
Update readme to point to most recent version of library

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ Java language bindings for the Librato Metrics API.
     <dependency>
         <groupId>com.librato.metrics</groupId>
         <artifactId>librato-java</artifactId>
-        <version>0.0.4</version>
+        <version>0.1.0</version>
     </dependency>


### PR DESCRIPTION
Looks like Maven Central now has 0.1.0 so updating the README.
