### PR TITLE
Fix Java regex syntax for disallowed characters

### DIFF
--- a/src/main/java/com/librato/metrics/Sanitizer.java
+++ b/src/main/java/com/librato/metrics/Sanitizer.java
@@ -22,7 +22,7 @@ public interface Sanitizer {
      */
     @SuppressWarnings("unused")
     public static final Sanitizer LAST_PASS = new Sanitizer() {
-        private final Pattern disallowedCharacters = Pattern.compile("([^A-Za-z0-9.:-_]|[\\[\\]]|\\s)");
+        private final Pattern disallowedCharacters = Pattern.compile("([^A-Za-z0-9.:\\-_]|[\\[\\]]|\\s)");
         private final int lengthLimit = 256;
 
         public String apply(String name) {


### PR DESCRIPTION
The dash character needs to be escaped so that it is not treated as regular expression syntax for a range of characters between the colon and underscore (':-_').
