### PR TITLE
Implemented ability to specify source for counter or gauge

### DIFF
--- a/src/main/java/com/librato/metrics/CounterMeasurement.java
+++ b/src/main/java/com/librato/metrics/CounterMeasurement.java
@@ -9,12 +9,22 @@ import static com.librato.metrics.Preconditions.checkNotNull;
  * Represents a reading from a counter
  */
 public class CounterMeasurement implements Measurement {
+    private final String source;
     private final String name;
     private final Long count;
 
     public CounterMeasurement(String name, Long count) {
+        this(null, name, count);
+    }
+
+    public CounterMeasurement(String source, String name, Long count) {
+        this.source = source;
         this.name = checkNotNull(name);
         this.count = checkNotNull(count);
+    }
+
+    public String getSource() {
+        return source;
     }
 
     public String getName() {

--- a/src/main/java/com/librato/metrics/LibratoBatch.java
+++ b/src/main/java/com/librato/metrics/LibratoBatch.java
@@ -67,8 +67,16 @@ public class LibratoBatch {
         addMeasurement(new CounterMeasurement(name, value));
     }
 
+    public void addCounterMeasurement(String source, String name, Long value) {
+        addMeasurement(new CounterMeasurement(source, name, value));
+    }
+
     public void addGaugeMeasurement(String name, Number value) {
         addMeasurement(new SingleValueGaugeMeasurement(name, value));
+    }
+
+    public void addGaugeMeasurement(String source, String name, Number value) {
+        addMeasurement(new SingleValueGaugeMeasurement(source, name, value));
     }
 
     public void post(String source, long epoch) {
@@ -85,6 +93,9 @@ public class LibratoBatch {
             final Measurement measurement = measurementIterator.next();
             final Map<String, Object> data = new HashMap<String, Object>();
             data.put("name", sanitizer.apply(measurement.getName()));
+            if (measurement.getSource() != null) {
+                data.put("source", sanitizer.apply(measurement.getSource()));
+            }
             data.putAll(measurement.toMap());
             if (measurement instanceof CounterMeasurement) {
                 counterData.add(data);

--- a/src/main/java/com/librato/metrics/Measurement.java
+++ b/src/main/java/com/librato/metrics/Measurement.java
@@ -8,6 +8,11 @@ import java.util.Map;
 public interface Measurement {
 
     /**
+     * @return the source of the measurement
+     */
+    public String getSource();
+
+    /**
      * @return the name of the measurement
      */
     public String getName();

--- a/src/main/java/com/librato/metrics/MultiSampleGaugeMeasurement.java
+++ b/src/main/java/com/librato/metrics/MultiSampleGaugeMeasurement.java
@@ -12,6 +12,7 @@ import static com.librato.metrics.Preconditions.checkNumeric;
  * See http://dev.librato.com/v1/post/metrics for why some fields are optional
  */
 public class MultiSampleGaugeMeasurement implements Measurement {
+    private final String source;
     private final String name;
     private final Long count;
     private final Number sum;
@@ -25,10 +26,21 @@ public class MultiSampleGaugeMeasurement implements Measurement {
                                        Number max,
                                        Number min,
                                        Number sumSquares) {
+        this(null, name, count, sum, max, min, sumSquares);
+    }
+
+    public MultiSampleGaugeMeasurement(String source,
+                                       String name,
+                                       Long count,
+                                       Number sum,
+                                       Number max,
+                                       Number min,
+                                       Number sumSquares) {
         try {
             if (count == null || count == 0) {
                 throw new IllegalArgumentException("The Librato API requires the count to be > 0 for complex metrics. See http://dev.librato.com/v1/post/metrics");
             }
+            this.source = source;
             this.name = checkNotNull(name);
             this.count = count;
             this.sum = checkNumeric(sum);
@@ -38,6 +50,10 @@ public class MultiSampleGaugeMeasurement implements Measurement {
         } catch (Exception e) {
             throw new IllegalArgumentException("Invalid multi-sample gauge measurement name=" + name, e);
         }
+    }
+
+    public String getSource() {
+        return source;
     }
 
     public String getName() {

--- a/src/main/java/com/librato/metrics/SingleValueGaugeMeasurement.java
+++ b/src/main/java/com/librato/metrics/SingleValueGaugeMeasurement.java
@@ -12,16 +12,26 @@ import static com.librato.metrics.Preconditions.checkNumeric;
  * See http://dev.librato.com/v1/post/metrics for an explanation of basic vs multi-sample gauge
  */
 public class SingleValueGaugeMeasurement implements Measurement {
+    private final String source;
     private final String name;
     private final Number reading;
 
     public SingleValueGaugeMeasurement(String name, Number reading) {
+        this(null, name, reading);
+    }
+
+    public SingleValueGaugeMeasurement(String source, String name, Number reading) {
         try {
+            this.source = source;
             this.name = checkNotNull(name);
             this.reading = checkNumeric(checkNumeric(reading));
         } catch (Exception e) {
             throw new IllegalArgumentException("Invalid single-gauge measurement name=" + name, e);
         }
+    }
+
+    public String getSource() {
+        return source;
     }
 
     public String getName() {

--- a/src/test/java/com/librato/metrics/Counter.java
+++ b/src/test/java/com/librato/metrics/Counter.java
@@ -4,6 +4,8 @@ import org.codehaus.jackson.annotate.JsonProperty;
 
 public class Counter {
     @JsonProperty
+    String source;
+    @JsonProperty
     String name;
     @JsonProperty
     Number value;
@@ -13,12 +15,24 @@ public class Counter {
     }
 
     public Counter(String name, Number value) {
+        this(null, name, value);
+    }
+
+    public Counter(String source, String name, Number value) {
+        this.source = source;
         this.name = name;
         this.value = value;
     }
 
+    public static Counter of(String source, String name, Number value) {
+        return new Counter(source, name, value);
+    }
     public static Counter of(String name, Number value) {
         return new Counter(name, value);
+    }
+
+    String getSource() {
+        return source;
     }
 
     String getName() {
@@ -36,6 +50,7 @@ public class Counter {
 
         Counter counter = (Counter) o;
 
+        if (source != null ? !source.equals(counter.source) : counter.source != null) return false;
         if (name != null ? !name.equals(counter.name) : counter.name != null) return false;
         if (value != null ? !value.equals(counter.value) : counter.value != null) return false;
 
@@ -45,6 +60,7 @@ public class Counter {
     @Override
     public int hashCode() {
         int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (source != null ? source.hashCode() : 0);
         result = 31 * result + (value != null ? value.hashCode() : 0);
         return result;
     }
@@ -52,7 +68,8 @@ public class Counter {
     @Override
     public String toString() {
         return "Counter{" +
-                "name='" + name + '\'' +
+                "source='" + source + '\'' +
+                ", name='" + name + '\'' +
                 ", value=" + value +
                 '}';
     }

--- a/src/test/java/com/librato/metrics/CounterMeasurementTest.java
+++ b/src/test/java/com/librato/metrics/CounterMeasurementTest.java
@@ -8,6 +8,16 @@ import static junit.framework.Assert.assertEquals;
 
 public class CounterMeasurementTest {
     @Test
+    public void testAllowNullSource() {
+        new CounterMeasurement(null, "my.fancy.counter", 17L);
+    }
+
+    @Test
+    public void testAllowSource() {
+        new CounterMeasurement("my.fancy.source", "my.fancy.counter", 17L);
+    }
+
+    @Test
     public void testCorrectMap() throws Exception {
         CounterMeasurement counterMeasurement = new CounterMeasurement("my.fancy.counter", 17L);
         Map<String, Number> map = counterMeasurement.toMap();

--- a/src/test/java/com/librato/metrics/Gauge.java
+++ b/src/test/java/com/librato/metrics/Gauge.java
@@ -4,6 +4,8 @@ import org.codehaus.jackson.annotate.JsonProperty;
 
 public class Gauge {
     @JsonProperty
+    String source;
+    @JsonProperty
     String name;
     @JsonProperty
     Number value;
@@ -13,8 +15,25 @@ public class Gauge {
     }
 
     public Gauge(String name, Number value) {
+        this(null, name, value);
+    }
+
+    public Gauge(String source, String name, Number value) {
+        this.source = source;
         this.name = name;
         this.value = value;
+    }
+
+    public static Gauge of(String name, int value) {
+        return new Gauge(name, value);
+    }
+
+    public static Gauge of(String source, String name, int value) {
+        return new Gauge(source, name, value);
+    }
+
+    public String getSource() {
+        return source;
     }
 
     public String getName() {
@@ -32,6 +51,7 @@ public class Gauge {
 
         Gauge gauge = (Gauge) o;
 
+        if (source != null ? !source.equals(gauge.source) : gauge.source != null) return false;
         if (name != null ? !name.equals(gauge.name) : gauge.name != null) return false;
         if (value != null ? !value.equals(gauge.value) : gauge.value != null) return false;
 
@@ -41,6 +61,7 @@ public class Gauge {
     @Override
     public int hashCode() {
         int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (source != null ? source.hashCode() : 0);
         result = 31 * result + (value != null ? value.hashCode() : 0);
         return result;
     }
@@ -48,12 +69,9 @@ public class Gauge {
     @Override
     public String toString() {
         return "Gauge{" +
-                "name='" + name + '\'' +
+                "source=" + source + '\'' +
+                ", name='" + name + '\'' +
                 ", value=" + value +
                 '}';
-    }
-
-    public static Gauge of(String name, int value) {
-        return new Gauge(name, value);
     }
 }

--- a/src/test/java/com/librato/metrics/LibratoBatchTest.java
+++ b/src/test/java/com/librato/metrics/LibratoBatchTest.java
@@ -44,6 +44,26 @@ public class LibratoBatchTest {
     }
 
     @Test
+    public void testPostsACounterWithSource() throws Exception {
+        final Response response = new FakeResponse(200);
+        final Future<Response> future = ReturningFuture.of(response);
+        Mockito.when(poster.post(anyString(), anyString())).thenReturn(future);
+        final long epoch = System.currentTimeMillis();
+        final LibratoBatch batch = new LibratoBatch(1, Sanitizer.NO_OP, 1, TimeUnit.SECONDS, agent, poster);
+        batch.addCounterMeasurement("farm", "apples", 1L);
+        batch.post(source, epoch);
+
+        ArgumentCaptor<String> payloadCapture = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(poster).post(Matchers.eq("test-agent librato-java/unknown"), payloadCapture.capture());
+        final Payload payload = Payload.parse(payloadCapture.getValue());
+        assertEquals(source, payload.getSource());
+        assertEquals(1, payload.getCounters().size());
+        assertEquals(0, payload.getGauges().size());
+        assertEquals(Counter.of("farm", "apples", 1), payload.getCounters().iterator().next());
+        assertEquals(epoch, payload.getMeasureTime());
+    }
+
+    @Test
     public void testPostsAGauge() throws Exception {
         final Response response = new FakeResponse(200);
         final Future<Response> future = ReturningFuture.of(response);
@@ -60,6 +80,26 @@ public class LibratoBatchTest {
         assertEquals(0, payload.getCounters().size());
         assertEquals(1, payload.getGauges().size());
         assertEquals(Gauge.of("apples", 1), payload.getGauges().iterator().next());
+        assertEquals(epoch, payload.getMeasureTime());
+    }
+
+    @Test
+    public void testPostsAGaugeWithSource() throws Exception {
+        final Response response = new FakeResponse(200);
+        final Future<Response> future = ReturningFuture.of(response);
+        Mockito.when(poster.post(anyString(), anyString())).thenReturn(future);
+        final long epoch = System.currentTimeMillis();
+        final LibratoBatch batch = new LibratoBatch(1, Sanitizer.NO_OP, 1, TimeUnit.SECONDS, agent, poster);
+        batch.addGaugeMeasurement("farm", "apples", 1L);
+        batch.post(source, epoch);
+
+        ArgumentCaptor<String> payloadCapture = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(poster).post(Matchers.eq("test-agent librato-java/unknown"), payloadCapture.capture());
+        final Payload payload = Payload.parse(payloadCapture.getValue());
+        assertEquals(source, payload.getSource());
+        assertEquals(0, payload.getCounters().size());
+        assertEquals(1, payload.getGauges().size());
+        assertEquals(Gauge.of("farm", "apples", 1), payload.getGauges().iterator().next());
         assertEquals(epoch, payload.getMeasureTime());
     }
 

--- a/src/test/java/com/librato/metrics/MultiSampleGaugeMeasurementTest.java
+++ b/src/test/java/com/librato/metrics/MultiSampleGaugeMeasurementTest.java
@@ -6,6 +6,16 @@ import org.junit.Test;
  * Verify that all the advanced details are filled in that are available
  */
 public class MultiSampleGaugeMeasurementTest {
+    @Test
+    public void testAllowNullSource() {
+        new MultiSampleGaugeMeasurement(null, "testGauge", 12L, 2, 2, 2, 2);
+    }
+
+    @Test
+    public void testAllowSource() {
+        new MultiSampleGaugeMeasurement("my.fancy.source", "testGauge", 12L, 2, 2, 2, 2);
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void doesNotAcceptNaNAsSum() {
         new MultiSampleGaugeMeasurement("testGauge", 12L, Double.NaN, 2, 2, 2);

--- a/src/test/java/com/librato/metrics/SingleValueGaugeMeasurementTest.java
+++ b/src/test/java/com/librato/metrics/SingleValueGaugeMeasurementTest.java
@@ -8,6 +8,16 @@ import static org.junit.Assert.assertEquals;
 
 public class SingleValueGaugeMeasurementTest {
     @Test
+    public void testAllowNullSource() {
+        new SingleValueGaugeMeasurement(null, "my.fancy.gauge", 17L);
+    }
+
+    @Test
+    public void testAllowSource() {
+        new SingleValueGaugeMeasurement("my.fancy.source", "my.fancy.gauge", 17L);
+    }
+
+    @Test
     public void testCorrectMap() throws Exception {
         SingleValueGaugeMeasurement single = new SingleValueGaugeMeasurement("my.fancy.gauge", 45L);
         Map<String, Number> map = single.toMap();


### PR DESCRIPTION
Hi,

I have implemented ability to specify source for **any value** of counter or gauge as described in [spec](http://dev.librato.com/v1/post/metrics). 

> source and measure_time can also be specified as a parameters outside of the gauges and counters measurement hashes. In this case the given source and measure_time values will be applied to all values submitted unless those measurements have another source or measure_time specified in their sub-hashes.

Could you please check PR and deploy new version to Maven repository?

Thanks
