### PR TITLE
bump async-http-client dependency to version 1.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.ning</groupId>
             <artifactId>async-http-client</artifactId>
-            <version>1.7.4</version>
+            <version>1.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>


### PR DESCRIPTION
The current 1.7.4 is over 3 years old and the build including the tests succeed with the latest version of async-http-client.

Could you consider updating the dependencies?
