### PR TITLE
Allow measure_time to be set for each measurement

### DIFF
--- a/src/main/java/com/librato/metrics/CounterMeasurement.java
+++ b/src/main/java/com/librato/metrics/CounterMeasurement.java
@@ -16,6 +16,7 @@ public class CounterMeasurement implements Measurement {
     private final String name;
     private final Long count;
     private final Map<String, Object> metricAttributes;
+    private final Long measureTime;
 
     public static CounterMeasurementBuilder builder(String name, Long count) {
         return new CounterMeasurementBuilder(name, count);
@@ -30,15 +31,20 @@ public class CounterMeasurement implements Measurement {
     }
 
     public CounterMeasurement(String source, Number period, String name, Long count) {
-        this(source, period, name, count, emptyAttributes);
+        this(source, period, name, count, emptyAttributes, null);
     }
 
-    public CounterMeasurement(String source, Number period, String name, Long count, Map<String, Object> metricAttributes) {
+    public CounterMeasurement(String source, Number period, String name, Long count, Map<String, Object> metricAttributes, Long measureTime) {
         this.source = source;
         this.period = period;
         this.name = checkNotNull(name);
         this.count = checkNotNull(count);
         this.metricAttributes = metricAttributes;
+        this.measureTime = measureTime;
+    }
+
+    public Long getMeasureTime() {
+        return measureTime;
     }
 
     public Map<String, Object> getMetricAttributes() {

--- a/src/main/java/com/librato/metrics/CounterMeasurementBuilder.java
+++ b/src/main/java/com/librato/metrics/CounterMeasurementBuilder.java
@@ -9,6 +9,7 @@ public class CounterMeasurementBuilder {
     private String source = null;
     private Number period = null;
     private Map<String, Object> metricAttributes = new HashMap<String, Object>();
+    private Long measureTime;
 
     public CounterMeasurementBuilder(String name, Long count) {
         this.name = name;
@@ -30,7 +31,12 @@ public class CounterMeasurementBuilder {
         return this;
     }
 
+    public CounterMeasurementBuilder setMeasureTime(Long measureTime) {
+        this.measureTime = measureTime;
+        return this;
+    }
+
     public CounterMeasurement build() {
-        return new CounterMeasurement(source, period, name, count, metricAttributes);
+        return new CounterMeasurement(source, period, name, count, metricAttributes, measureTime);
     }
 }

--- a/src/main/java/com/librato/metrics/LibratoBatch.java
+++ b/src/main/java/com/librato/metrics/LibratoBatch.java
@@ -118,6 +118,9 @@ public class LibratoBatch {
             if (!measurement.getMetricAttributes().isEmpty()) {
                 data.put("attributes", measurement.getMetricAttributes());
             }
+            if (measurement.getMeasureTime() != null) {
+                data.put("measure_time", measurement.getMeasureTime());
+            }
             data.putAll(measurement.toMap());
             if (measurement instanceof CounterMeasurement) {
                 counterData.add(data);

--- a/src/main/java/com/librato/metrics/Measurement.java
+++ b/src/main/java/com/librato/metrics/Measurement.java
@@ -8,6 +8,13 @@ import java.util.Map;
 public interface Measurement {
 
     /**
+     * @return the (unix) timestamp of the measure. Optional, null returned if no specific time
+     * is present. Instead the measure time will be taken from the top level of the POST
+     * payload to Librato
+     */
+    Long getMeasureTime();
+
+    /**
      * @return the source of the measurement
      */
     String getSource();

--- a/src/main/java/com/librato/metrics/MultiSampleGaugeMeasurement.java
+++ b/src/main/java/com/librato/metrics/MultiSampleGaugeMeasurement.java
@@ -21,6 +21,7 @@ public class MultiSampleGaugeMeasurement implements Measurement {
     private final Number min;
     private final Number sumSquares;
     private final Map<String, Object> metricAttributes;
+    private final Long measureTime;
 
     public static MultiSampleGaugeMeasurementBuilder builder(String name) {
         return new MultiSampleGaugeMeasurementBuilder(name);
@@ -34,7 +35,8 @@ public class MultiSampleGaugeMeasurement implements Measurement {
                                        Number max,
                                        Number min,
                                        Number sumSquares,
-                                       Map<String, Object> metricAttributes) {
+                                       Map<String, Object> metricAttributes,
+                                       Long measureTime) {
         try {
             if (count == null || count == 0) {
                 throw new IllegalArgumentException("The Librato API requires the count to be > 0 for complex metrics. See http://dev.librato.com/v1/post/metrics");
@@ -48,9 +50,14 @@ public class MultiSampleGaugeMeasurement implements Measurement {
             this.min = checkNumeric(min);
             this.sumSquares = checkNumeric(sumSquares);
             this.metricAttributes = metricAttributes;
+            this.measureTime = measureTime;
         } catch (Exception e) {
             throw new IllegalArgumentException("Invalid multi-sample gauge measurement name=" + name, e);
         }
+    }
+
+    public Long getMeasureTime() {
+        return measureTime;
     }
 
     public Map<String, Object> getMetricAttributes() {

--- a/src/main/java/com/librato/metrics/MultiSampleGaugeMeasurementBuilder.java
+++ b/src/main/java/com/librato/metrics/MultiSampleGaugeMeasurementBuilder.java
@@ -13,9 +13,15 @@ public class MultiSampleGaugeMeasurementBuilder {
     private Number min;
     private Number sumSquares;
     private Map<String, Object> metricAttributes = new HashMap<String, Object>();
+    private Long measureTime;
 
     public MultiSampleGaugeMeasurementBuilder(String name) {
         this.name = name;
+    }
+
+    public MultiSampleGaugeMeasurementBuilder setMeasureTime(Long measureTime) {
+        this.measureTime = measureTime;
+        return this;
     }
 
     public MultiSampleGaugeMeasurementBuilder setSource(String source) {
@@ -59,6 +65,6 @@ public class MultiSampleGaugeMeasurementBuilder {
     }
 
     public MultiSampleGaugeMeasurement build() {
-        return new MultiSampleGaugeMeasurement(source, period, name, count, sum, max, min, sumSquares, metricAttributes);
+        return new MultiSampleGaugeMeasurement(source, period, name, count, sum, max, min, sumSquares, metricAttributes, measureTime);
     }
 }

--- a/src/main/java/com/librato/metrics/SingleValueGaugeMeasurement.java
+++ b/src/main/java/com/librato/metrics/SingleValueGaugeMeasurement.java
@@ -19,6 +19,7 @@ public class SingleValueGaugeMeasurement implements Measurement {
     private final String name;
     private final Number reading;
     private final Map<String, Object> metricAttributes;
+    private Long measureTime;
 
     public static SingleValueGaugeMeasurementBuilder builder(String name, Number reading) {
         return new SingleValueGaugeMeasurementBuilder(name, reading);
@@ -33,19 +34,24 @@ public class SingleValueGaugeMeasurement implements Measurement {
     }
 
     public SingleValueGaugeMeasurement(String source, Number period, String name, Number reading) {
-        this(source, period, name, reading, emptyAttributes);
+        this(source, period, name, reading, emptyAttributes, null);
     }
 
-    public SingleValueGaugeMeasurement(String source, Number period, String name, Number reading, Map<String, Object> metricAttributes) {
+    public SingleValueGaugeMeasurement(String source, Number period, String name, Number reading, Map<String, Object> metricAttributes, Long measureTime) {
         try {
             this.source = source;
             this.period = period;
             this.name = checkNotNull(name);
             this.reading = checkNumeric(checkNumeric(reading));
             this.metricAttributes = metricAttributes;
+            this.measureTime = measureTime;
         } catch (Exception e) {
             throw new IllegalArgumentException("Invalid single-gauge measurement name=" + name, e);
         }
+    }
+
+    public Long getMeasureTime() {
+        return measureTime;
     }
 
     public Map<String, Object> getMetricAttributes() {

--- a/src/main/java/com/librato/metrics/SingleValueGaugeMeasurementBuilder.java
+++ b/src/main/java/com/librato/metrics/SingleValueGaugeMeasurementBuilder.java
@@ -9,6 +9,7 @@ public class SingleValueGaugeMeasurementBuilder {
     private String source = null;
     private Number period = null;
     private Map<String, Object> metricAttributes = new HashMap<String, Object>();
+    private Long measureTime;
 
     public SingleValueGaugeMeasurementBuilder(String name, Number reading) {
         this.name = name;
@@ -30,7 +31,12 @@ public class SingleValueGaugeMeasurementBuilder {
         return this;
     }
 
+    public SingleValueGaugeMeasurementBuilder setMeasureTime(Long measureTime) {
+        this.measureTime = measureTime;
+        return this;
+    }
+
     public SingleValueGaugeMeasurement build() {
-        return new SingleValueGaugeMeasurement(source, period, name, reading, metricAttributes);
+        return new SingleValueGaugeMeasurement(source, period, name, reading, metricAttributes, measureTime);
     }
 }

--- a/src/test/java/com/librato/metrics/Counter.java
+++ b/src/test/java/com/librato/metrics/Counter.java
@@ -16,8 +16,11 @@ public class Counter {
     Number value;
     @JsonProperty
     Map<String, Object> attributes = Collections.emptyMap();
+    @JsonProperty("measure_time")
+    Long measureTime;
 
     public Counter() {
+
         // jackson
     }
 
@@ -79,6 +82,7 @@ public class Counter {
         if (period != null ? !period.equals(counter.period) : counter.period != null) return false;
         if (name != null ? !name.equals(counter.name) : counter.name != null) return false;
         if (value != null ? !value.equals(counter.value) : counter.value != null) return false;
+        if (measureTime != null ? !measureTime.equals(counter.measureTime) : counter.measureTime != null) return false;
 
         return true;
     }

--- a/src/test/java/com/librato/metrics/Gauge.java
+++ b/src/test/java/com/librato/metrics/Gauge.java
@@ -20,6 +20,8 @@ public class Gauge {
     Long count;
     @JsonProperty
     Number sum;
+    @JsonProperty("measure_time")
+    Long measureTime;
 
     public Gauge() {
         // jackson
@@ -86,6 +88,7 @@ public class Gauge {
         if (source != null ? !source.equals(gauge.source) : gauge.source != null) return false;
         if (sum != null ? !sum.equals(gauge.sum) : gauge.sum != null) return false;
         if (value != null ? !value.equals(gauge.value) : gauge.value != null) return false;
+        if (measureTime != null ? !measureTime.equals(gauge.measureTime) : gauge.measureTime != null) return false;
 
         return true;
     }
@@ -99,6 +102,7 @@ public class Gauge {
         result = 31 * result + (attributes != null ? attributes.hashCode() : 0);
         result = 31 * result + (count != null ? count.hashCode() : 0);
         result = 31 * result + (sum != null ? sum.hashCode() : 0);
+        result = 31 * result + (measureTime != null ? measureTime.hashCode() : 0);
         return result;
     }
 


### PR DESCRIPTION
The various measurement builder classes now let you set measure time on any particular measurement.  This overrides the measure time set in the overall payload.