### PR TITLE
HttpPoster interface now extends Closeable

### DIFF
--- a/src/main/java/com/librato/metrics/HttpPoster.java
+++ b/src/main/java/com/librato/metrics/HttpPoster.java
@@ -1,12 +1,13 @@
 package com.librato.metrics;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.Future;
 
 /**
  * Posts data to an HTTP endpoint.
  */
-public interface HttpPoster {
+public interface HttpPoster extends Closeable {
     /**
      * A generic interface to represent an HTTP response
      */

--- a/src/main/java/com/librato/metrics/NingHttpPoster.java
+++ b/src/main/java/com/librato/metrics/NingHttpPoster.java
@@ -107,4 +107,8 @@ public class NingHttpPoster implements HttpPoster {
         builder.setBody(payload);
         return new FutureAdapter(builder.execute());
     }
+
+    public void close() throws IOException {
+      httpClient.close();
+    }
 }


### PR DESCRIPTION
The `HttpPoster` interface now extends `Closeable` and for `NingHttpPoster` closing an instance closes the underlying `AysncHttpClient` instance.

The rationale for the change is that some versions of
`AsyncHttpClient` instances create non-daemon threads for its
internal infrastructure.  Since they are non-daemon those threads
prevent the JVM from shutting down unless killed, preventing process
monitors from automatically restarting applications and possibly
circumventing graceful shutdown logic.

This behavior is observed when using async-http-client versions of 1.8 and later; though this library references version v1.7.4 we have other dependencies which coerce the version to be later.

Related to https://github.com/AsyncHttpClient/async-http-client/issues/926