### PR TITLE
Add getResponse method to PostResult

### DIFF
--- a/src/main/java/com/librato/metrics/PostResult.java
+++ b/src/main/java/com/librato/metrics/PostResult.java
@@ -42,6 +42,10 @@ public class PostResult {
         return data;
     }
 
+    public String getResponse() {
+        return response;
+    }
+
     @Override
     public String toString() {
         return "PostResult{" +


### PR DESCRIPTION
This would be useful for constructing custom error messages where the exception is null. In scala, I'd like to be able to do something like this: 

    logger.error("Error posting metrics to librato, response: " + result.getFailedPosts.asScala.map(pr => pr.response))

There might be a reason for this to not be exposed, if so no problem, just thought I'd suggest it.