### PR TITLE
Upgrade to latest async http client.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>com.ning</groupId>
             <artifactId>async-http-client</artifactId>
-            <version>1.7.4</version>
+            <version>1.9.32</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>


### PR DESCRIPTION
We're having an issue in our play 2.4.6 applications which depend on netty 3.10 which appears to be subtly breaking the async http client 1.7 which depends on netty 3.4. We were able to resolve the issue by forcing an update to 1.9.33 on our end. Since this seems to work fine, I assume the ideal thing to do is update the dependency here.