### PR TITLE
Bump  jackson from codehaus to fasterxml. fix javadocs errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,9 +94,19 @@
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.7</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.6.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.6.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.6.7</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/com/librato/metrics/LibratoBatch.java
+++ b/src/main/java/com/librato/metrics/LibratoBatch.java
@@ -1,6 +1,6 @@
 package com.librato.metrics;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.*;
 import java.util.concurrent.ExecutionException;
@@ -56,6 +56,7 @@ public class LibratoBatch {
 
     /**
      * for advanced measurement fu
+     * @param measurement measurement param
      */
     public void addMeasurement(Measurement measurement) {
         measurements.add(measurement);

--- a/src/main/java/com/librato/metrics/MultiSampleGaugeMeasurement.java
+++ b/src/main/java/com/librato/metrics/MultiSampleGaugeMeasurement.java
@@ -8,7 +8,7 @@ import static com.librato.metrics.Preconditions.checkNumeric;
 
 /**
  * A class for representing a gauge reading that might come from multiple samples
- * <p/>
+ * <p>
  * See http://dev.librato.com/v1/post/metrics for why some fields are optional
  */
 public class MultiSampleGaugeMeasurement implements Measurement {

--- a/src/main/java/com/librato/metrics/SingleValueGaugeMeasurement.java
+++ b/src/main/java/com/librato/metrics/SingleValueGaugeMeasurement.java
@@ -9,7 +9,7 @@ import static com.librato.metrics.Preconditions.checkNumeric;
 
 /**
  * A class representing a single gauge reading
- * <p/>
+ * <p>
  * See http://dev.librato.com/v1/post/metrics for an explanation of basic vs multi-sample gauge
  */
 public class SingleValueGaugeMeasurement implements Measurement {

--- a/src/test/java/com/librato/metrics/Counter.java
+++ b/src/test/java/com/librato/metrics/Counter.java
@@ -1,6 +1,6 @@
 package com.librato.metrics;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Collections;
 import java.util.Map;

--- a/src/test/java/com/librato/metrics/Gauge.java
+++ b/src/test/java/com/librato/metrics/Gauge.java
@@ -1,6 +1,6 @@
 package com.librato.metrics;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Collections;
 import java.util.Map;

--- a/src/test/java/com/librato/metrics/Payload.java
+++ b/src/test/java/com/librato/metrics/Payload.java
@@ -1,7 +1,7 @@
 package com.librato.metrics;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.List;


### PR DESCRIPTION
The version of jackson used in librato java is obsolete moved to a newer version 
