### PR TITLE
Allow empty email and format auth token correctly for appoptics

### DIFF
--- a/src/main/java/com/librato/metrics/client/Authorization.java
+++ b/src/main/java/com/librato/metrics/client/Authorization.java
@@ -16,13 +16,16 @@ public class Authorization {
      * @return the Authorization header value
      */
     public static String buildAuthHeader(String username, String token) {
-        if (username == null || "".equals(username)) {
-            throw new IllegalArgumentException("Username must be specified");
-        }
+        String fullToken = "";
         if (token == null || "".equals(token)) {
             throw new IllegalArgumentException("Token must be specified");
         }
-        return String.format("Basic %s", base64Encode((username + ":" + token).getBytes(Charset.forName("UTF-8"))));
+        if (username != null && username.length() > 0) {
+            fullToken += username + ":" + token;
+        } else {
+            fullToken += token + ":";
+        }
+        return String.format("Basic %s", base64Encode((fullToken).getBytes(Charset.forName("UTF-8"))));
     }
 
     private static String base64Encode(byte[] bytes) {

--- a/src/test/java/com/librato/metrics/client/AuthorizationTest.java
+++ b/src/test/java/com/librato/metrics/client/AuthorizationTest.java
@@ -3,11 +3,11 @@ package com.librato.metrics.client;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.charset.Charset;
+
+import javax.xml.bind.DatatypeConverter;
+
 public class AuthorizationTest {
-    @Test(expected = IllegalArgumentException.class)
-    public void testAuthHeaderRejectsEmptyUsername() throws Exception {
-        Authorization.buildAuthHeader(null, "token");
-    }
 
     @Test(expected = IllegalArgumentException.class)
     public void testAuthHeaderRejectsEmptyToken() throws Exception {
@@ -15,8 +15,16 @@ public class AuthorizationTest {
     }
 
     @Test
+    public void testEmptyEmailForAppOpticsToken() {
+        final String header = Authorization.buildAuthHeader("", "token");
+        Assert.assertEquals("Basic dG9rZW46", header);
+    }
+
+    @Test
     public void testProducesTheCorrectHeader() throws Exception {
         final String header = Authorization.buildAuthHeader("username", "token");
         Assert.assertEquals("Basic dXNlcm5hbWU6dG9rZW4=", header);
     }
+
+
 }

--- a/src/test/java/com/librato/metrics/client/LibratoClientTest.java
+++ b/src/test/java/com/librato/metrics/client/LibratoClientTest.java
@@ -177,12 +177,6 @@ public class LibratoClientTest {
                 LibratoClient.builder("foo@example.com", null).build();
             }
         });
-        ensureIllegalArgument(new Runnable() {
-            @Override
-            public void run() {
-                LibratoClient.builder(null, "token").build();
-            }
-        });
         LibratoClient.builder("foo@example.com", "token").build();
     }
 


### PR DESCRIPTION
- Basically, we can use an appoptics url with this library as the protocol appears to be the same, the only change we need is to support the way appoptics uses the token